### PR TITLE
Fix hashtable_remove breaking linear probe chains

### DIFF
--- a/hashtable.c
+++ b/hashtable.c
@@ -27,6 +27,7 @@ struct hashtable {
 #endif
 
 #define HASHTABLE_INITIAL_CAPACITY 4
+#define HASHTABLE_TOMBSTONE ((char*)-1)
 
 /**
  * Compute the hash value for the given string.
@@ -46,8 +47,10 @@ unsigned long hashtable_hash(char* str)
  */
 unsigned int hashtable_find_slot(hashtable* t, char* key)
 {
+	assert(key != NULL && key != HASHTABLE_TOMBSTONE);
 	int index = hashtable_hash(key) % t->capacity;
-	while (t->body[index].key != NULL && strcmp(t->body[index].key, key) != 0) {
+	while (t->body[index].key != NULL &&
+	       (t->body[index].key == HASHTABLE_TOMBSTONE || strcmp(t->body[index].key, key) != 0)) {
 		index = (index + 1) % t->capacity;
 	}
 	return index;
@@ -95,7 +98,7 @@ void hashtable_remove(hashtable* t, char* key)
 {
 	int index = hashtable_find_slot(t, key);
 	if (t->body[index].key != NULL) {
-		t->body[index].key = NULL;
+		t->body[index].key = HASHTABLE_TOMBSTONE;
 		t->body[index].value = NULL;
 		t->size--;
 	}
@@ -135,7 +138,7 @@ void hashtable_resize(hashtable* t, unsigned int capacity)
 
 	// Copy all the old values into the newly allocated body
 	for (int i = 0; i < old_capacity; i++) {
-		if (old_body[i].key != NULL) {
+		if (old_body[i].key != NULL && old_body[i].key != HASHTABLE_TOMBSTONE) {
 			hashtable_set(t, old_body[i].key, old_body[i].value);
 		}
 	}

--- a/tests.c
+++ b/tests.c
@@ -130,5 +130,33 @@ int main()
 
 	hashtable_destroy(t);
 
+	/*
+	 * Test: hashtable_remove should not break linear probing chains.
+	 * Keys "ab" and "ba" both hash to the same slot (0) with capacity 4.
+	 * Removing "ab" should not prevent finding "ba".
+	 */
+	hashtable* t2 = hashtable_create();
+
+	hashtable_set(t2, "ab", a);  // Goes to slot 0
+	hashtable_set(t2, "ba", b);  // Collision, goes to slot 1
+
+	// Both should be findable
+	assert(hashtable_get(t2, "ab") == a);
+	assert(hashtable_get(t2, "ba") == b);
+
+	// Remove the first one in the chain
+	hashtable_remove(t2, "ab");
+
+	// "ba" should still be findable (this will fail with the current bug)
+	assert(hashtable_get(t2, "ba") == b);
+
+	// Re-insert "ab" with a different value
+	hashtable_set(t2, "ab", c);
+	assert(hashtable_get(t2, "ab") == c);
+	assert(hashtable_get(t2, "ba") == b);  // "ba" should still work
+	assert(t2->size == 2);
+
+	hashtable_destroy(t2);
+
 	printf("All tests completed.\n");
 }


### PR DESCRIPTION
Use tombstone sentinels instead of NULL when removing entries, so that `hashtable_find_slot` can probe past deleted slots.

Fixes #1
