### PR TITLE
Fix memory leak in hashtable_resize

### DIFF
--- a/hashtable.c
+++ b/hashtable.c
@@ -143,6 +143,7 @@ void hashtable_resize(hashtable* t, unsigned int capacity)
 			hashtable_set(t, old_body[i].key, old_body[i].value);
 		}
 	}
+	free(old_body);
 }
 
 /**


### PR DESCRIPTION
Free the old body after copying entries to the new allocation.